### PR TITLE
feat: start simple footer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Footer from "@/components/footer";
 import Gift from "@/components/gift";
 import  Hero  from "@/components/hero";
 import LocationAndSuggestions from "@/components/localAndSuggestion";
@@ -16,7 +17,7 @@ export default function Home() {
       <LocationAndSuggestions />
       <ScrollingBanner />
       <Gift />
-
+      <Footer />
     </>
   );
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,18 @@
+export default function Footer() {
+    return (
+      <footer className="py-6 sm:py-8 lg:py-12 bg-[var(--background)] border-t border-black font-kodchasan">
+        <div className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12">
+          <div className="flex flex-col items-center justify-center">
+            <p className="text-black text-xs sm:text-sm md:text-base lg:text-lg text-center max-w-xs sm:max-w-md md:max-w-2xl lg:max-w-4xl leading-relaxed sm:leading-loose">
+              "Melhor é serem dois do que um, porque se caírem, um levanta o outro. O cordão de três dobras não se rebenta
+              com facilidade."
+              <span className="block mt-2 sm:mt-3 md:mt-4 text-[10px] sm:text-xs md:text-sm lg:text-base opacity-60 sm:opacity-70 md:opacity-75">
+                (Eclesiastes 4:9,10,12)
+              </span>
+            </p>
+          </div>
+        </div>
+      </footer>
+    )
+  }
+  


### PR DESCRIPTION
This pull request introduces a new `Footer` component to the application and integrates it into the `Home` page. The most important changes include creating the `Footer` component, importing it into the `Home` page, and adding it to the page layout.

### Addition of the `Footer` component:
* [`src/components/footer.tsx`](diffhunk://#diff-febe472312c34362d6340a54dd876572b5ef8731d37a0d895c9b6b1f2ead8a8eR1-R18): A new `Footer` component was created, featuring a styled footer section with a quote from Ecclesiastes and responsive design considerations.

### Integration of the `Footer` component into the `Home` page:
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR1): The `Footer` component was imported into the `Home` page.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL19-R20): The `Footer` component was added to the layout of the `Home` page, positioned after the `Gift` component.